### PR TITLE
Create prometheus stats dir outside OMERO.web dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Optional:
 - `omero_web_django_prometheus_config_web`: Automatically set `omero.web.*` configuration properties, default `True`.
 - `omero_web_django_prometheus_stats_dir`: Prometheus temporary statistics directory
 
-
 **Warning** This will make configuration changes to the OMERO.web and Gunicorn configurations, see [`templates/omero-web-config-django-prometheus-omero.j2`](templates/omero-web-config-django-prometheus-omero.j2) and [`defaults/main.yml`](defaults/main.yml) for details.
 
 If you have customised your OMERO.web installation such as installing other web apps or setting `omero.web` configuration properties ensure the configuration changes made by this role are compatible.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Role Variables
 
 Optional:
 - `omero_web_django_prometheus_config_web`: Automatically set `omero.web.*` configuration properties, default `True`.
+- `omero_web_django_prometheus_stats_dir`: Prometheus temporary statistics directory
+
 
 **Warning** This will make configuration changes to the OMERO.web and Gunicorn configurations, see [`templates/omero-web-config-django-prometheus-omero.j2`](templates/omero-web-config-django-prometheus-omero.j2) and [`defaults/main.yml`](defaults/main.yml) for details.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@
 # Automatically set omero.web.* configuration properties
 omero_web_django_prometheus_config_web: True
 
+# Prometheus temporary statistics directory
+omero_web_django_prometheus_stats_dir: "{{ omero_common_basedir }}/web/prometheus/stats"
+
 
 ######################################################################
 # Expert users only!

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,11 +43,12 @@
   - reload systemd
   - restart omero-web
 
-# systemd service should create this directory but sometimes it's absence
-# on the first restart causes problems
+# systemd service should create this directory but this may be required
+# for other invocations of bin/omero including ExecStartPre
 - name: omero-web django prometheus | stats dir
   become: yes
   file:
-    path: "{{ omero_common_basedir }}/web/OMERO.web/var/prometheus"
+    path: "{{ omero_web_django_prometheus_stats_dir }}"
+    recurse: yes
     state: directory
     owner: "{{ omero_web_system_user | default('omero-web') }}"

--- a/templates/systemd-system-omero-web-service-d-prometheus-conf.j2
+++ b/templates/systemd-system-omero-web-service-d-prometheus-conf.j2
@@ -1,4 +1,3 @@
 [Service]
-Environment="prometheus_multiproc_dir={{ omero_common_basedir }}/web/OMERO.web/var/prometheus"
-ExecStartPre=/bin/sh -c '/usr/bin/rm -rf "$prometheus_multiproc_dir" && \
-    /usr/bin/mkdir -p "$prometheus_multiproc_dir"'
+Environment="prometheus_multiproc_dir={{ omero_web_django_prometheus_stats_dir }}"
+ExecStartPre=/bin/sh -c '/usr/bin/rm -rf "$prometheus_multiproc_dir/"*'


### PR DESCRIPTION
This ensures prometheus_multiproc_dir is not lost on upgrade, which may lead to OMERO.web failing to restart since some ExecStartPre bin/omero steps may require the presence of the dir even if web isn't yet running.

This also deletes the contents of prometheus_multiproc_dir isntead of deleting and recreating the dir itself.

This is a required bug-fix for systems using the existing version of this role, otherwise OMERO.web may fail to restart after an upgrade.