### PR TITLE
OMERO.web 5.6+ Python 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+# Changes in Version 0.3
+
+## Summary of breaking changes
+- Only OMERO.web 5.6+ Python 3 is supported.
+  Use an older version of this role for Python 2.7.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OMERO.web django-prometheus
 [![Ansible Role](https://img.shields.io/ansible/role/42003.svg)](https://galaxy.ansible.com/ome/omero_web_django_prometheus/)
 
 Install and configure Django Prometheus exporter for OMERO.web.
-Assumes OMERO.web has been installed using the ome.omero_web role.
+Assumes OMERO.web 5.6+ Python 3 has been installed using the [ome.omero_web](https://galaxy.ansible.com/ome/omero_web) role.
 
 See https://github.com/korfuri/django-prometheus
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ omero_web_django_prometheus_stats_dir: >-
 ######################################################################
 
 # django-prometheus version
-omero_web_django_prometheus_version: 1.0.14
+omero_web_django_prometheus_version: 1.1.0
 
 # OMERO.web doesn't support appending to omero.web.wsgi_arg,
 # we can only override it

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,8 +3,4 @@
   hosts: all
   roles:
     - role: ome.omero_web
-      # Use precompiled IcePy to speed up installation
-      ice_python_wheel: >-
-        https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.0.3/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
-
     - role: ansible-role-omero-web-django-prometheus

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,2 +1,4 @@
 ---
-- src: ome.omero_web
+- name: ome.omero_web
+  src: >-
+    https://github.com/ome/ansible-role-omero-web/archive/53a2bc3b31e48ce201d15ff81e974d1c17b58516.tar.gz

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,4 +1,2 @@
 ---
-- name: ome.omero_web
-  src: >-
-    https://github.com/ome/ansible-role-omero-web/archive/53a2bc3b31e48ce201d15ff81e974d1c17b58516.tar.gz
+- src: ome.omero_web

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     name: django-prometheus
     state: present
     version: "{{ omero_web_django_prometheus_version }}"
-    virtualenv: "{{ omero_common_basedir }}/web/venv"
+    virtualenv: "{{ omero_common_basedir }}/web/venv3"
     virtualenv_site_packages: true
   notify:
     - restart omero-web


### PR DESCRIPTION
Drops support for OMERO.web <5.6

Requires https://github.com/ome/ansible-role-omero-web/pull/34 (Travis should pass after a re-run when it is released)

Tag: breaking change, `0.3.0`