### PR TITLE
Avoid too-many-file error when deleting $prometheus_multiproc_dir

### DIFF
--- a/templates/systemd-system-omero-web-service-d-prometheus-conf.j2
+++ b/templates/systemd-system-omero-web-service-d-prometheus-conf.j2
@@ -1,3 +1,3 @@
 [Service]
 Environment="prometheus_multiproc_dir={{ omero_web_django_prometheus_stats_dir }}"
-ExecStartPre=/bin/sh -c '/usr/bin/rm -rf "$prometheus_multiproc_dir/"*'
+ExecStartPre=/usr/bin/find "{{ omero_web_django_prometheus_stats_dir }}" -mindepth 1 -delete


### PR DESCRIPTION
The Django prometheus exporter creates temporary record files under `$prometheus_multiproc_dir`. These files should be deleted when omero-web starts by a systemd startup script, but there is a pathological case where an error causes 10000s of temporary files to be created (this is not related to the recent update, it's occurred in the past but I've now hit it a second time). The shell then fails to delete them all due to too many arguments begin passed to `rm`. This switches to using `find ... -delete` instead.

Tag: bugfix, `0.4.1`